### PR TITLE
bugfix

### DIFF
--- a/Pring/Document.swift
+++ b/Pring/Document.swift
@@ -163,13 +163,7 @@ public extension Document {
 
     public func listen(_ block: @escaping (Self?, Error?) -> Void) -> ListenerRegistration {
         let options: DocumentListenOptions = DocumentListenOptions()
-        var isFirst: Bool = true
         return self.reference.addSnapshotListener(options: options) { (snapshot, error) in
-            // Do not process at the first time
-            if isFirst {
-                isFirst = false
-                return
-            }
             guard let snapshot: DocumentSnapshot = snapshot, snapshot.exists else {
                 block(nil, error)
                 return


### PR DESCRIPTION
The `isFirst` variable is always `true`. Therefore, I think these codes are unnecessary(but I do not know the detailed reasons why this process was necessary...)