### PR TITLE
Fixed DataType for parsing dictionary correctly.

### DIFF
--- a/Pring/DataType.swift
+++ b/Pring/DataType.swift
@@ -290,6 +290,16 @@ public enum DataType {
                 self = .reference(key, rawValue, reference)
                 return
             }
+        } else if value is [String: Any] {
+            if let value: [String: Any] = data[key] as? [String: Any] {
+                self = .dictionary(key, value, value)
+                return
+            }
+        } else if value is [AnyHashable: Any] {
+            if let value: [String: Any] = data[key] as? [String: Any] {
+                self = .dictionary(key, value, value)
+                return
+            }
         } else {
             self = .null
         }


### PR DESCRIPTION
I just fixed DataType.swift for parsing dictionary(`[String: Any]` and `[AnyHashable: Any])`) correctly.