### PR TITLE
Equip `foreach` in Datastore for working correctly.

### DIFF
--- a/Pring/DataSource.swift
+++ b/Pring/DataSource.swift
@@ -429,6 +429,10 @@ extension DataSource: Collection {
     public subscript(index: Int) -> Element {
         return self.documents[index]
     }
+
+    public func forEach(_ body: (T) throws -> Void) rethrows {
+        return try self.documents.forEach(body)
+    }
 }
 
 extension Array where Element: Document {


### PR DESCRIPTION
I just added `foreach` function in DataSource.


- before

```swift
for i in (0..<dataSource.count) {
    let data = dataSource[i]
    // ...
}

// Not working...
dataSource.foreach { data in
}
```

- After

```swift
dataSource.foreach { data in
    // ...
}
```