### PR TITLE
Feature/fix nested collection remove

### DIFF
--- a/Pring/NestedCollection.swift
+++ b/Pring/NestedCollection.swift
@@ -200,10 +200,10 @@ public final class NestedCollection<T: Object>: SubCollection, ExpressibleByArra
                 let batch: WriteBatch = Firestore.firestore().batch()
                 batch.deleteDocument(reference)
                 batch.commit(completion: {(error) in
+                    member.set(Element.reference.document())
                     block?(error)
                 })
             })
-            member.set(Element.reference.document())
         } else {
             _self.remove(member)
             member.set(Element.reference.document())

--- a/Pring/NestedCollection.swift
+++ b/Pring/NestedCollection.swift
@@ -203,10 +203,10 @@ public final class NestedCollection<T: Object>: SubCollection, ExpressibleByArra
                     block?(error)
                 })
             })
-            member.set(type(of: member).reference.document())
+            member.set(Element.reference.document())
         } else {
             _self.remove(member)
-            member.set(type(of: member).reference.document())
+            member.set(Element.reference.document())
             block?(nil)
         }
     }


### PR DESCRIPTION
I fixed bug in NestedCollection.

In remove function, `type(of member)` is crashed by memory `BAD ACCESS`.
So I use `Element` instead of that method for getting nested object type.

And reset member's reference without waiting for deletion results.
So I move reset function into result of deletion.