### PR TITLE
Init updateValue in init(id: String, value:[AnyHasable: Any])

### DIFF
--- a/Pring/Object.swift
+++ b/Pring/Object.swift
@@ -195,6 +195,7 @@ open class Object: NSObject, Document {
                 }
             }
         }
+        updateValue = [:]
         self.isSaved = true
     }
 


### PR DESCRIPTION
When called `init(id: String, value:[AnyHasable: Any])`, starts key value observing by `self.init()`.
And called setValue in `init(id: String, value:[AnyHasable: Any])` below of `self.init()`, so `Object.updateValue` has all members.
So I set empty `Dictionary` after of `setValue`.