### PR TITLE
Fix empty collection handling

### DIFF
--- a/Pring/DataSource.swift
+++ b/Pring/DataSource.swift
@@ -199,6 +199,7 @@ public final class DataSource<T: Document>: ExpressibleByArrayLiteral {
             if isFirst {
                 guard let lastSnapshot = snapshot.documents.last else {
                     // The collection is empty.
+                    block?(snapshot, .initial)
                     return
                 }
                 self.query = self.query.start(afterDocument: lastSnapshot)


### PR DESCRIPTION
I'm getting infinity loading when start to listen empty collection