### PR TITLE
Override isEqual() for Object.

### DIFF
--- a/Pring/Object.swift
+++ b/Pring/Object.swift
@@ -716,6 +716,14 @@ extension Object {
     open override var hashValue: Int {
         return self.id.hash
     }
+        
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let obj = object as? Object else {
+            return false
+        }
+        return self == obj
+    }
+    
     public static func == (lhs: Object, rhs: Object) -> Bool {
         return lhs.id == rhs.id && type(of: lhs).modelVersion == type(of: rhs).modelVersion
     }


### PR DESCRIPTION
Hi, 1amageek.
When I use the contains method of Array, I found it does not work because your Object extends from NSObject.
```Swift 
class User: Object {
    dynamic var name: String = ""
}
users.contains(user)
```
To solve this issue, I tries to override the isEqual() method for Object and the contains() method works well.